### PR TITLE
updated token length

### DIFF
--- a/lib/getAvailableTokens.ts
+++ b/lib/getAvailableTokens.ts
@@ -1,7 +1,7 @@
 import getTokenHolders from "./getTokenHolders";
 
 const MIN_TOKEN = 1;
-const MAX_TOKEN = 8000;
+const MAX_TOKEN = 7777;
 
 export default async function getAvailableTokens() {
 	const tokens = await getTokenHolders();


### PR DESCRIPTION
Hi @fmoliveira , first off this project has been awesome and very helpful for developers joining the community, thank you for that.

Second, I wanted to update the available tokens to take into account a restriction that is in the contract that stops minting at 7777. Anyone trying to mint one of the ids 7778 - 8000 will not be able to unless they are the contract owner.

This is to leave a reserve for us to mint tokens for select community members who want come in after we sell out, to do giveaways, and to possibly fundraise after we sell out. As it looks, we are starting to get close as we have over 5,092 meaning there are only 2,685 left.

https://etherscan.io/address/0x25ed58c027921e14d86380ea2646e3a1b5c55a8b#code#L1527

Thanks for your help again, and see you in the DAO!
<img width="536" alt="Screen Shot 2021-11-06 at 4 04 18 PM" src="https://user-images.githubusercontent.com/1857282/140616138-092c12b4-27db-400e-a547-8fef7a055911.png">
